### PR TITLE
Replace removed jcenter() with mavenCentral() for Gradle 9

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     ext.kotlin_version = '1.5.30'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -17,7 +17,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
## Why

Gradle 9 removed the `jcenter()` method from the repository DSL, so consuming apps on Gradle 9 fail to configure this plugin with `Could not find method jcenter()`. (JCenter itself shut down in 2021.)

## What

- Replace both `jcenter()` calls (in `buildscript` and `rootProject.allprojects`) with `mavenCentral()`, which serves the same artifacts.